### PR TITLE
Feat/004 notebook onehot categoricals

### DIFF
--- a/notebooks/churn_regression.ipynb
+++ b/notebooks/churn_regression.ipynb
@@ -84,9 +84,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "5",
+   "metadata": {},
+   "source": [
+    "### 1) EDA sanity checks (feat/notebook-eda-sanity)\n",
+    "\n",
+    "Goal: quick data validation from customers_clean."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -104,9 +114,52 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "7",
+   "metadata": {},
+   "source": [
+    "### 2) Baseline logistic regression (feat/notebook-baseline-logreg)\n",
+    "\n",
+    "Goal: simple baseline using the three engineered features you already have."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.preprocessing import StandardScaler\n",
+    "from sklearn.linear_model import LogisticRegression\n",
+    "from sklearn.pipeline import Pipeline\n",
+    "from sklearn.metrics import roc_auc_score\n",
+    "\n",
+    "X = df[['is_monthly','auto_pay','short_tenure']].astype(float)\n",
+    "y = df['churn'].astype(int)\n",
+    "ids = df['id'].astype(str)\n",
+    "\n",
+    "X_tr, X_te, y_tr, y_te, id_tr, id_te = train_test_split(\n",
+    "    X, y, ids, test_size=0.25, random_state=42, stratify=y\n",
+    ")\n",
+    "\n",
+    "pipe = Pipeline([\n",
+    "    ('scaler', StandardScaler(with_mean=False)),\n",
+    "    ('logreg', LogisticRegression(max_iter=2000, solver='lbfgs', class_weight=None))\n",
+    "]).fit(X_tr, y_tr)\n",
+    "\n",
+    "p_tr = pipe.predict_proba(X_tr)[:,1]\n",
+    "p_te = pipe.predict_proba(X_te)[:,1]\n",
+    "\n",
+    "print(f\"AUC train: {roc_auc_score(y_tr, p_tr):.3f}\")\n",
+    "print(f\"AUC test : {roc_auc_score(y_te, p_te):.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/notebooks/churn_regression.ipynb
+++ b/notebooks/churn_regression.ipynb
@@ -157,9 +157,97 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "9",
+   "metadata": {},
+   "source": [
+    "### 3) One-hot encode key categoricals (feat/notebook-onehot-categoricals)\n",
+    "\n",
+    "Goal: lift performance by adding SQL columns and one-hot in sklearn.\n",
+    "\n",
+    "First, adjust the SQL query to include these (already in customers_clean):\n",
+    "\n",
+    "Contract, PaymentMethod, gender, age_group, tenure (numeric), MonthlyCharges (numeric)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "QUERY_PLUS = \"\"\"\n",
+    "SELECT\n",
+    "  customerID AS id,\n",
+    "  is_monthly, auto_pay,\n",
+    "  CASE WHEN tenure < 12 THEN 1 ELSE 0 END AS short_tenure,\n",
+    "  Contract, PaymentMethod, gender, age_group,\n",
+    "  tenure, MonthlyCharges,\n",
+    "  churn\n",
+    "FROM customers_clean;\n",
+    "\"\"\"\n",
+    "conn = mc.connect(\n",
+    "    host=os.getenv(\"MYSQL_HOST\"), port=int(os.getenv(\"MYSQL_PORT\")),\n",
+    "    user=os.getenv(\"MYSQL_USER\"), password=os.getenv(\"MYSQL_PASSWORD\"),\n",
+    "    database=os.getenv(\"MYSQL_DB\")\n",
+    ")\n",
+    "df2 = pd.read_sql(QUERY_PLUS, conn); conn.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11",
+   "metadata": {},
+   "source": [
+    "Fit with ColumnTransformer:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.compose import ColumnTransformer\n",
+    "from sklearn.preprocessing import OneHotEncoder\n",
+    "\n",
+    "num_cols = ['tenure','MonthlyCharges']\n",
+    "bin_cols = ['is_monthly','auto_pay','short_tenure']\n",
+    "cat_cols = ['Contract','PaymentMethod','gender','age_group']\n",
+    "\n",
+    "X = df2[bin_cols + num_cols + cat_cols].copy()\n",
+    "y = df2['churn'].astype(int)\n",
+    "ids = df2['id'].astype(str)\n",
+    "\n",
+    "X_tr, X_te, y_tr, y_te, id_tr, id_te = train_test_split(\n",
+    "    X, y, ids, test_size=0.25, random_state=42, stratify=y\n",
+    ")\n",
+    "\n",
+    "pre = ColumnTransformer(\n",
+    "    transformers=[\n",
+    "        ('num', 'passthrough', num_cols),\n",
+    "        ('bin', 'passthrough', bin_cols),\n",
+    "        ('cat', OneHotEncoder(handle_unknown='ignore', drop=None), cat_cols)\n",
+    "    ]\n",
+    ")\n",
+    "pipe2 = Pipeline([\n",
+    "    ('prep', pre),\n",
+    "    ('logreg', LogisticRegression(max_iter=5000, solver='lbfgs'))\n",
+    "]).fit(X_tr, y_tr)\n",
+    "\n",
+    "from sklearn.metrics import roc_auc_score\n",
+    "p_tr = pipe2.predict_proba(X_tr)[:,1]\n",
+    "p_te = pipe2.predict_proba(X_te)[:,1]\n",
+    "print(f\"AUC train: {roc_auc_score(y_tr, p_tr):.3f}\")\n",
+    "print(f\"AUC test : {roc_auc_score(y_te, p_te):.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/notebooks/churn_regression.ipynb
+++ b/notebooks/churn_regression.ipynb
@@ -89,6 +89,26 @@
    "id": "5",
    "metadata": {},
    "outputs": [],
+   "source": [
+    "import pandas as pd, numpy as np\n",
+    "\n",
+    "print(df.shape)\n",
+    "display(df.head(3))\n",
+    "\n",
+    "# Basic label balance\n",
+    "df['churn'].value_counts().rename_axis('label').to_frame('count')\n",
+    "df['churn'].value_counts(normalize=True).mul(100).round(2).rename('pct')\n",
+    "\n",
+    "# Leakage check: make sure target not in features\n",
+    "set(df.columns) - {'id','is_monthly','auto_pay','short_tenure','churn'}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
    "source": []
   }
  ],

--- a/notebooks/churn_regression.ipynb
+++ b/notebooks/churn_regression.ipynb
@@ -163,7 +163,7 @@
    "source": [
     "### 3) One-hot encode key categoricals (feat/notebook-onehot-categoricals)\n",
     "\n",
-    "Goal: lift performance by adding SQL columns and one-hot in sklearn.\n",
+    "Goal: lift performance by adding SQL columns  and one-hot in sklearn.\n",
     "\n",
     "First, adjust the SQL query to include these (already in customers_clean):\n",
     "\n",
@@ -192,65 +192,8 @@
     "    user=os.getenv(\"MYSQL_USER\"), password=os.getenv(\"MYSQL_PASSWORD\"),\n",
     "    database=os.getenv(\"MYSQL_DB\")\n",
     ")\n",
-    "df2 = pd.read_sql(QUERY_PLUS, conn); conn.close()"
+    "df2 = pd.read_sql(QUERY_PLUS, conn); conn.close()\n"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "11",
-   "metadata": {},
-   "source": [
-    "Fit with ColumnTransformer:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "12",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from sklearn.compose import ColumnTransformer\n",
-    "from sklearn.preprocessing import OneHotEncoder\n",
-    "\n",
-    "num_cols = ['tenure','MonthlyCharges']\n",
-    "bin_cols = ['is_monthly','auto_pay','short_tenure']\n",
-    "cat_cols = ['Contract','PaymentMethod','gender','age_group']\n",
-    "\n",
-    "X = df2[bin_cols + num_cols + cat_cols].copy()\n",
-    "y = df2['churn'].astype(int)\n",
-    "ids = df2['id'].astype(str)\n",
-    "\n",
-    "X_tr, X_te, y_tr, y_te, id_tr, id_te = train_test_split(\n",
-    "    X, y, ids, test_size=0.25, random_state=42, stratify=y\n",
-    ")\n",
-    "\n",
-    "pre = ColumnTransformer(\n",
-    "    transformers=[\n",
-    "        ('num', 'passthrough', num_cols),\n",
-    "        ('bin', 'passthrough', bin_cols),\n",
-    "        ('cat', OneHotEncoder(handle_unknown='ignore', drop=None), cat_cols)\n",
-    "    ]\n",
-    ")\n",
-    "pipe2 = Pipeline([\n",
-    "    ('prep', pre),\n",
-    "    ('logreg', LogisticRegression(max_iter=5000, solver='lbfgs'))\n",
-    "]).fit(X_tr, y_tr)\n",
-    "\n",
-    "from sklearn.metrics import roc_auc_score\n",
-    "p_tr = pipe2.predict_proba(X_tr)[:,1]\n",
-    "p_te = pipe2.predict_proba(X_te)[:,1]\n",
-    "print(f\"AUC train: {roc_auc_score(y_tr, p_tr):.3f}\")\n",
-    "print(f\"AUC test : {roc_auc_score(y_te, p_te):.3f}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "13",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary
Add comprehensive evaluation of the logistic regression model using ROC and precision-recall curves, along with a classification report at the default 0.5 threshold. This provides transparency into model performance and tradeoffs.

## Changes
- Generated ROC curve with AUC value.
- Generated precision-recall curve with average precision score.
- Added classification_report at default threshold.
- Included matplotlib plots inline.

## How to Test
1. Ensure the pipeline from Step 3 has been trained and p_te (test probabilities) is available.
2. Run new evaluation cells.
3. Verify that plots render and metrics print.

## Expected Outputs
- ROC curve plotted with AUC value (≈0.8 expected).
- Precision-recall curve plotted with AP value.
- Text classification report with precision/recall/F1 for both classes.

## Acceptance Criteria
- [ ] Plots render without errors in Jupyter Notebook.
- [ ] Metrics provide interpretable results for both classes.
- [ ] No sensitive information committed
- [ ] No changes to upstream pipeline code.

## Checklist
- [ ] Notebook cells run cleanly without warnings/errors.
- [ ] Plots saved in outputs or clear instructions to re-generate.
- [ ] README unchanged (evaluation documented inline in notebook).