### PR TITLE
Add ROC/PR curves and classification report

### DIFF
--- a/notebooks/churn_regression.ipynb
+++ b/notebooks/churn_regression.ipynb
@@ -118,9 +118,8 @@
    "id": "7",
    "metadata": {},
    "source": [
-    "### 2) Baseline logistic regression (feat/notebook-baseline-logreg)\n",
-    "\n",
-    "Goal: simple baseline using the three engineered features you already have."
+    "### Step 2: Baseline Logistic Regression\n",
+    "As a first model, we use logistic regression with only three engineered features: `is_monthly`, `auto_pay`, and `short_tenure`. This provides a simple, interpretable baseline to measure against more complex feature sets later. The model outputs churn probabilities for each customer, and performance is summarized by the AUC score on train and test splits.\n"
    ]
   },
   {
@@ -157,25 +156,18 @@
    ]
   },
   {
-
    "cell_type": "markdown",
    "id": "9",
    "metadata": {},
    "source": [
-    "### 3) One-hot encode key categoricals (feat/notebook-onehot-categoricals)\n",
-    "\n",
-    "Goal: lift performance by adding SQL columns  and one-hot in sklearn.\n",
-    "\n",
-    "First, adjust the SQL query to include these (already in customers_clean):\n",
-    "\n",
-    "Contract, PaymentMethod, gender, age_group, tenure (numeric), MonthlyCharges (numeric)"
+    "### Step 3: One-hot encode categoricals\n",
+    "Categorical features like contract type and payment method can’t be used directly in regression models, so we convert them into binary indicators using one-hot encoding. This allows the model to capture differences across categories without assuming any numeric order. Adding these features should improve performance compared with the simple baseline.\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "10",
-    
    "metadata": {},
    "outputs": [],
    "source": [
@@ -196,6 +188,50 @@
     ")\n",
     "df2 = pd.read_sql(QUERY_PLUS, conn); conn.close()\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11",
+   "metadata": {},
+   "source": [
+    "### Step 4: ROC, Precision-Recall, and Classification Report\n",
+    "To understand model performance beyond accuracy, we use ROC and Precision-Recall curves. ROC shows how well the model separates churners from non-churners at different thresholds, summarized by AUC. Precision-Recall is especially useful with imbalanced data, highlighting tradeoffs between catching churners (recall) and avoiding false alarms (precision).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "from sklearn.metrics import roc_curve, auc, precision_recall_curve, average_precision_score, classification_report\n",
+    "\n",
+    "# ROC\n",
+    "fpr, tpr, _ = roc_curve(y_te, p_te)\n",
+    "roc_auc = auc(fpr, tpr)\n",
+    "plt.figure(); plt.plot(fpr,tpr,label=f\"AUC={roc_auc:.3f}\"); plt.plot([0,1],[0,1],'--')\n",
+    "plt.xlabel(\"FPR\"); plt.ylabel(\"TPR\"); plt.title(\"ROC\"); plt.legend(); plt.show()\n",
+    "\n",
+    "# PR\n",
+    "prec, rec, _ = precision_recall_curve(y_te, p_te)\n",
+    "ap = average_precision_score(y_te, p_te)\n",
+    "plt.figure(); plt.plot(rec, prec, label=f\"AP={ap:.3f}\")\n",
+    "plt.xlabel(\"Recall\"); plt.ylabel(\"Precision\"); plt.title(\"Precision-Recall\"); plt.legend(); plt.show()\n",
+    "\n",
+    "# Default 0.5 report\n",
+    "y_hat = (p_te >= 0.5).astype(int)\n",
+    "print(classification_report(y_te, y_hat, digits=3))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary
Add comprehensive evaluation of the logistic regression model using ROC and precision-recall curves, along with a classification report at the default 0.5 threshold. This provides transparency into model performance and tradeoffs.

## Changes
- Generated ROC curve with AUC value.
- Generated precision-recall curve with average precision score.
- Added classification_report at default threshold.
- Included matplotlib plots inline.

## How to Test
1. Ensure the pipeline from Step 3 has been trained and p_te (test probabilities) is available.
2. Run new evaluation cells.
3. Verify that plots render and metrics print.

## Expected Outputs
- ROC curve plotted with AUC value (≈0.8 expected).
- Precision-recall curve plotted with AP value.
- Text classification report with precision/recall/F1 for both classes.

## Acceptance Criteria
- [x] Plots render without errors in Jupyter Notebook.
- [x] Metrics provide interpretable results for both classes.
- [x] No changes to upstream pipeline code.

## Checklist
- [x] Notebook cells run cleanly without warnings/errors.
- [x] Plots saved in outputs or clear instructions to re-generate.
- [x] README unchanged (evaluation documented inline in notebook).