### PR TITLE
feat(sql): add sanity checks and simple SQL-only risk score script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,35 @@
 # Ignore zip files
 .zip
 
-# Data
-/data/*
-!/data/archive/*
-
 #Ignore Venv
 .venv
+
+# -------------------
+# Data & Artifacts
+# -------------------
+
+# Raw/derived data exports
+data/*.csv
+!data/*latest.csv 
+!data/README.md          # allow small docs to describe data
+
+# Model binaries
+notebooks/artifacts/logreg_pipeline.joblib
+notebooks/artifacts/*.joblib
+notebooks/artifacts/*.pkl
+notebooks/artifacts/*.h5
+
+# Model metadata: keep JSON cards under version control
+!notebooks/artifacts/*.json
+
+# -------------------
+# Jupyter & Python
+# -------------------
+.ipynb_checkpoints/
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.egg-info/
+dist/
+build/

--- a/README.md
+++ b/README.md
@@ -107,3 +107,11 @@ Before running the notebook, prepare the database:
    ```bash
    mysql -u churn -p churn_project < sql/01_post_load_transformations.sql
    ```
+
+4. Optional: SQL Sanity Checks and Baseline Scoring
+
+You can run additional queries to sanity-check the data and create a simple SQL-only churn score:
+
+```bash
+mysql -u churn -p churn_project < sql/02_sanity_checks_and_baseline.sql
+```


### PR DESCRIPTION
## Summary
Adds a dedicated SQL script for quick data sanity checks and a transparent, rule-based churn score. This showcases SQL-first analysis and provides a baseline to compare with ML models.

## Changes
- New file: sql/02_sanity_checks_and_baseline.sql with:
    - Basic table sample
    - Overall churn rate
    - Churn by contract type
    - churn_score column with weighted rules
    - Optional CSV export for logistic regression features (Linux path), and optional user grants
- README: short section on how to run this optional script.

## How to Test
```bash
# assuming DB is prepared and customers_clean exists
mysql -u churn -p churn_project < sql/02_sanity_checks_and_baseline.sql

# spot checks
mysql -u churn -p churn_project -e "SHOW COLUMNS FROM customers_clean LIKE 'churn_score';"
mysql -u churn -p churn_project -e "SELECT COUNT(*) FROM customers_clean WHERE churn_score IS NOT NULL;"
```

## Expected Outputs
- Printed churn rates and small sample rows.
- customers_clean.churn_score populated.
- Optional: churn_regression.csv written to server secure dir if configured.

## Checklist
- [ ] Script runs without errors on MySQL 8.
- [ ] No dependency on LOCAL INFILE for this script.
- [ ] README mentions script as optional.
